### PR TITLE
Big round of tests against Runtime and bugfixing

### DIFF
--- a/src/common/DeviceInfoState.ts
+++ b/src/common/DeviceInfoState.ts
@@ -1,7 +1,22 @@
 /**
+ * Numeric device types which appear before the underscore in device ids.
+ */
+export enum DeviceType {
+  DUMMY = 0,
+  LIMIT_SWITCH = 1,
+  LINE_FOLLOWER = 2,
+  BATTERY_BUZZER = 3,
+  SERVO_CONTROLLER = 4,
+  POLAR_BEAR = 5,
+  KOALA_BEAR = 6,
+  PDB = 7,
+  DISTANCE_SENSOR = 8,
+}
+
+/**
  * Maps device types to user-friendly names.
  */
-export const DeviceTypes: { [type: number]: string } = {
+export const DeviceTypeNames: { [type: number]: string } = {
   0: 'Dummy device',
   1: 'Limit switch',
   2: 'Line follower',

--- a/src/common/DeviceInfoState.ts
+++ b/src/common/DeviceInfoState.ts
@@ -2,15 +2,46 @@
  * Numeric device types which appear before the underscore in device ids.
  */
 export enum DeviceType {
+  /**
+   * Dummy device type.
+   */
   DUMMY = 0,
+  /**
+   * Limit switch device type.
+   */
   LIMIT_SWITCH = 1,
+  /**
+   * Line follower device type.
+   */
   LINE_FOLLOWER = 2,
+  /**
+   * Battery buzzer device type. Not used anymore?
+   */
   BATTERY_BUZZER = 3,
+  /**
+   * Servo controller device type.
+   */
   SERVO_CONTROLLER = 4,
+  /**
+   * PolarBear device type. Not distributed with new kits.
+   */
   POLAR_BEAR = 5,
+  /**
+   * KoalaBear device type.
+   */
   KOALA_BEAR = 6,
+  /**
+   * Power distribution board device type.
+   */
   PDB = 7,
+  /**
+   * Distance sensor device type.
+   */
   DISTANCE_SENSOR = 8,
+  /**
+   * Stopwatch ("custom data" that tracks duration of connection in ms) device type.
+   */
+  STOPWATCH = 32,
 }
 
 /**
@@ -26,6 +57,7 @@ export const DeviceTypeNames: { [type: number]: string } = {
   6: 'KoalaBear motor controller',
   7: 'Power distribution board',
   8: 'Distance sensor',
+  32: 'Stopwatch',
 };
 
 /**

--- a/src/common/IpcEventTypes.ts
+++ b/src/common/IpcEventTypes.ts
@@ -39,10 +39,6 @@ export interface RendererInitData {
    */
   robotIPAddress: string;
   /**
-   * The IP address used to upload code to the robot, retrieved from persistent config.
-   */
-  robotSSHAddress: string;
-  /**
    * The IP address of the field controller, retrieved from persistent config.
    */
   fieldIPAddress: string;
@@ -286,10 +282,6 @@ export interface MainQuitData {
    * The IP address used to communicate with the robot's runtime, to be saved to persistent config.
    */
   robotIPAddress: string;
-  /**
-   * The IP address used to upload code to the robot, to be saved to persistent config.
-   */
-  robotSSHAddress: string;
   /**
    * The IP address of the field controller, to be saved to persistent config.
    */

--- a/src/main/MainApp.ts
+++ b/src/main/MainApp.ts
@@ -203,7 +203,6 @@ export default class MainApp implements MenuHandler, RuntimeCommsListener {
     addRendererListener('main-quit', (data) => {
       // Save config that may have been changed while the program was running
       this.#config.robotIPAddress = data.robotIPAddress;
-      this.#config.robotSSHAddress = data.robotSSHAddress;
       this.#config.fieldIPAddress = data.fieldIPAddress;
       this.#config.fieldStationNumber = data.fieldStationNumber;
       this.#config.showDirtyUploadWarning = data.showDirtyUploadWarning;
@@ -253,7 +252,6 @@ export default class MainApp implements MenuHandler, RuntimeCommsListener {
     this.#sendToRenderer('renderer-init', {
       dawnVersion,
       robotIPAddress: this.#config.robotIPAddress,
-      robotSSHAddress: this.#config.robotSSHAddress,
       fieldIPAddress: this.#config.fieldIPAddress,
       fieldStationNumber: this.#config.fieldStationNumber,
       showDirtyUploadWarning: this.#config.showDirtyUploadWarning,

--- a/src/main/MainApp.ts
+++ b/src/main/MainApp.ts
@@ -273,13 +273,15 @@ export default class MainApp implements MenuHandler, RuntimeCommsListener {
 
   onReceiveDevices(deviceInfoState: DeviceInfoState[]) {
     this.#sendToRenderer('renderer-devices-update', deviceInfoState);
-    const pdbs = deviceInfoState.filter((state) => state.id.split('_')[0] === DeviceType.PDB.toString());
-    if (pdbs.length != 1) {
+    const pdbs = deviceInfoState.filter(
+      (state) => state.id.split('_')[0] === DeviceType.PDB.toString(),
+    );
+    if (pdbs.length !== 1) {
       this.#sendToRenderer(
         'renderer-post-console',
         new AppConsoleMessage(
           'dawn-err',
-          'Not exactly one PDB is connected to the robot.',
+          'Cannot read battery voltage. Not exactly one PDB is connected to the robot.',
         ),
       );
     } else if (!('v_batt' in pdbs[0]) || Number.isNaN(Number(pdbs[0].v_batt))) {
@@ -302,18 +304,6 @@ export default class MainApp implements MenuHandler, RuntimeCommsListener {
         new AppConsoleMessage(
           'dawn-err',
           `Encountered TCP error when communicating with Runtime. ${err.toString()}`,
-        ),
-      );
-    }
-  }
-
-  onRuntimeUdpError(err: Error) {
-    if (!this.#suppressNetworkErrors) {
-      this.#sendToRenderer(
-        'renderer-post-console',
-        new AppConsoleMessage(
-          'dawn-err',
-          `Encountered UDP error when communicating with Runtime. ${err.toString()}`,
         ),
       );
     }

--- a/src/main/MainApp.ts
+++ b/src/main/MainApp.ts
@@ -40,21 +40,21 @@ const CODE_FILE_FILTERS: FileFilter[] = [
  */
 const CONFIG_RELPATH = 'dawn-config.json';
 /**
- * Path on robot to upload student code to.
- */
-const REMOTE_CODE_PATH = '/home/pi/runtime/executor/studentcode.py';
-/**
  * Port to use when connecting to robot with SSH.
  */
 const ROBOT_SSH_PORT = 22;
 /**
  * Username to log in as when connecting to robot with SSH.
  */
-const ROBOT_SSH_USER = 'pi';
+const ROBOT_SSH_USER = 'ubuntu';
 /**
  * Password to log in with when connecting to robot with SSH.
  */
-const ROBOT_SSH_PASS = 'raspberry';
+const ROBOT_SSH_PASS = 'potato';
+/**
+ * Path on robot to upload student code to.
+ */
+const REMOTE_CODE_PATH = `/home/${ROBOT_SSH_USER}/runtime/executor/studentcode.py`;
 
 /**
  * Adds a listener for the main-quit IPC event fired by the renderer.
@@ -393,7 +393,7 @@ export default class MainApp implements MenuHandler, RuntimeCommsListener {
   }
 
   /**
-   * Tries to load code from a file into the editor. Fails is the user does not choose a path.
+   * Tries to load code from a file into the editor. Fails if the user does not choose a path.
    */
   #openCodeFile() {
     const success = this.#showCodePathDialog('load');

--- a/src/main/network/PacketStream.ts
+++ b/src/main/network/PacketStream.ts
@@ -62,7 +62,7 @@ export default class PacketStream extends Transform {
     while (this.#tryReadPacket(shouldConcatHeader)) {
       shouldConcatHeader = false;
     }
-    callback(null, chunk);
+    callback();
   }
 
   /**

--- a/src/main/network/RuntimeComms.ts
+++ b/src/main/network/RuntimeComms.ts
@@ -82,6 +82,10 @@ export interface RuntimeCommsListener {
    * Called when the TCP connection to the robot is lost for any reason.
    */
   onRuntimeDisconnect: () => void;
+  /**
+   * Called when a TCP connection to the robot is established.
+   */
+  onRuntimeConnect: () => void;
 }
 
 /**
@@ -299,6 +303,7 @@ export default class RuntimeComms {
    * Handler for TCP 'connect' event.
    */
   #handleTcpConnection() {
+    this.#commsListener.onRuntimeConnect();
     if (this.#tcpSock) {
       this.#tcpSock.write(new Uint8Array([1])); // Tell Runtime that we are Dawn, not Shepherd
     }

--- a/src/main/network/RuntimeComms.ts
+++ b/src/main/network/RuntimeComms.ts
@@ -277,9 +277,6 @@ export default class RuntimeComms {
           (Date.now() - Number(protos.TimeStamps.decode(data).dawnTimestamp)) / 2,
         );
         break;
-      // case MsgType.CHALLENGE_DATA:
-      // TODO: ??? Not implemented in old Dawn
-      // break;
       case MsgType.DEVICE_DATA:
         // Convert decoded Devices to DeviceInfoStates before passing to onReceiveDevices
         this.#commsListener.onReceiveDevices(
@@ -395,9 +392,6 @@ export default class RuntimeComms {
           data as protos.ITimeStamps,
         ).finish();
         break;
-      // case MsgType.CHALLENGE_DATA:
-      // packetData = protos.Text.encode(data as protos.IText).finish();
-      // break;
       case MsgType.INPUTS:
         // Source says input data isn't usually sent through TCP? What's that about?
         packetData = protos.UserInputs.encode(

--- a/src/main/network/RuntimeComms.ts
+++ b/src/main/network/RuntimeComms.ts
@@ -274,7 +274,8 @@ export default class RuntimeComms {
         break;
       case MsgType.TIME_STAMPS:
         this.#commsListener.onReceiveLatency(
-          (Date.now() - Number(protos.TimeStamps.decode(data).dawnTimestamp)) / 2,
+          (Date.now() - Number(protos.TimeStamps.decode(data).dawnTimestamp)) /
+            2,
         );
         break;
       case MsgType.DEVICE_DATA:

--- a/src/main/network/RuntimeComms.ts
+++ b/src/main/network/RuntimeComms.ts
@@ -15,6 +15,8 @@ const PING_INTERVAL = 5000;
 
 /**
  * A type of packet.
+ * Note CHALLENGE_DATA type has been omitted since 2021 Dawn as Shepherd is now in charge of
+ * checking challenges.
  */
 enum MsgType {
   RUN_MODE = 0,
@@ -182,18 +184,6 @@ export default class RuntimeComms {
   sendDevicePreferences(deviceData: protos.IDevData) {
     if (this.#tcpSock) {
       this.#tcpSock.write(this.#createPacket(MsgType.DEVICE_DATA, deviceData));
-    }
-  }
-
-  /**
-   * Sends challenge data.
-   * @param data - the textual challenge data to send.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  sendChallengeInputs(data: protos.IText) {
-    if (this.#tcpSock) {
-      throw new Error('Not implemented.'); // MsgTypes from old dawn are inconsistent?
-      // this.#tcpSock.write(this.#createPacket(MsgType.CHALLENGE_DATA, data));
     }
   }
 
@@ -430,14 +420,6 @@ export default class RuntimeComms {
    * @returns The packet encoded in a Buffer
    */
   #createPacket(type: MsgType.TIME_STAMPS, data: protos.ITimeStamps): Buffer;
-
-  /*
-   * Encodes a challenge data packet.
-   * @param type - the packet type.
-   * @param data - the packet payload.
-   * @returns The packet encoded in a Buffer
-   */
-  // #createPacket(type: MsgType.CHALLENGE_DATA, data: protos.IText): Buffer;
 
   /**
    * Encodes an input state packet.

--- a/src/main/network/RuntimeComms.ts
+++ b/src/main/network/RuntimeComms.ts
@@ -322,9 +322,9 @@ export default class RuntimeComms {
     const { type, data } = packet;
     switch (type) {
       case MsgType.LOG:
-        // this.#commsListener.onReceiveRobotLogs(
-        //  protos.Text.decode(data).payload,
-        // );
+        this.#commsListener.onReceiveRobotLogs(
+          protos.Text.decode(data).payload,
+        );
         break;
       case MsgType.TIME_STAMPS:
         this.#commsListener.onReceiveLatency(

--- a/src/main/network/RuntimeComms.ts
+++ b/src/main/network/RuntimeComms.ts
@@ -130,6 +130,7 @@ export default class RuntimeComms {
     this.#tcpDisconnected = true; // Don't reconnect
     if (this.#pingInterval) {
       clearInterval(this.#pingInterval);
+      this.#pingInterval = null;
     }
     this.#disconnectTcp();
   }
@@ -273,7 +274,7 @@ export default class RuntimeComms {
         break;
       case MsgType.TIME_STAMPS:
         this.#commsListener.onReceiveLatency(
-          (Date.now() - Number(protos.TimeStamps.decode(data))) / 2,
+          (Date.now() - Number(protos.TimeStamps.decode(data).dawnTimestamp)) / 2,
         );
         break;
       // case MsgType.CHALLENGE_DATA:

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -104,7 +104,6 @@ export default function App() {
   );
   // Connection configuration
   const [IPAddress, setIPAddress] = useState('192.168.0.100');
-  const [SSHAddress, setSSHAddress] = useState('192.168.0.100');
   const [FieldIPAddress, setFieldIPAddress] = useState('localhost');
   const [FieldStationNum, setFieldStationNum] = useState('4');
   // Information about periperhals connected to the robot
@@ -128,8 +127,6 @@ export default function App() {
   const handleConnectionChange = (event: ConnectionConfigChangeEvent) => {
     if (event.name === 'IPAddress') {
       setIPAddress(event.value);
-    } else if (event.name === 'SSHAddress') {
-      setSSHAddress(event.value);
     } else if (event.name === 'FieldIPAddress') {
       setFieldIPAddress(event.value);
     } else if (event.name === 'FieldStationNum') {
@@ -180,14 +177,12 @@ export default function App() {
   const closeWindow = useCallback(() => {
     window.electron.ipcRenderer.sendMessage('main-quit', {
       robotIPAddress: IPAddress,
-      robotSSHAddress: SSHAddress,
       fieldIPAddress: FieldIPAddress,
       fieldStationNumber: FieldStationNum,
       showDirtyUploadWarning,
     });
   }, [
     IPAddress,
-    SSHAddress,
     FieldIPAddress,
     FieldStationNum,
     showDirtyUploadWarning,
@@ -219,13 +214,13 @@ export default function App() {
       if (editorStatus === 'clean' || activeModal === modalName) {
         window.electron.ipcRenderer.sendMessage('main-file-control', {
           type: isUpload ? 'upload' : 'download',
-          robotSSHAddress: SSHAddress,
+          robotSSHAddress: IPAddress,
         });
       } else {
         changeActiveModal(modalName);
       }
     },
-    [editorStatus, SSHAddress, activeModal],
+    [editorStatus, IPAddress, activeModal],
   );
   const createNewFile = useCallback(() => {
     if (editorStatus === 'clean' || activeModal === 'DirtyNewFileConfirm') {
@@ -316,7 +311,6 @@ export default function App() {
         window.electron.ipcRenderer.on('renderer-init', (data) => {
           setDawnVersion(data.dawnVersion);
           setIPAddress(data.robotIPAddress);
-          setSSHAddress(data.robotSSHAddress);
           setFieldIPAddress(data.fieldIPAddress);
           setFieldStationNum(data.fieldStationNumber);
           setShowDirtyUploadWarning(data.showDirtyUploadWarning);
@@ -477,7 +471,6 @@ export default function App() {
             onClose={closeModal}
             onChange={handleConnectionChange}
             IPAddress={IPAddress}
-            SSHAddress={SSHAddress}
             FieldIPAddress={FieldIPAddress}
             FieldStationNum={FieldStationNum}
           />

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -74,8 +74,8 @@ export default function App() {
   // closed)
   const [consoleIsAlerted, setConsoleIsAlerted] = useState(false);
   // Whether keyboard controls are enabled.
-  const [keyboardControlsEnabled, setKeyboardControlsEnabled] = useState(
-    'on' as KeyboardControlsStatus,
+  const [keyboardControlsStatus, setKeyboardControlsEnabled] = useState(
+    'off' as KeyboardControlsStatus,
   );
   // Whether the robot is running student code
   const [robotRunning, setRobotRunning] = useState(false);
@@ -282,17 +282,17 @@ export default function App() {
             source: RobotInputSource.GAMEPAD,
           });
         });
-      if (keyboardControlsEnabled !== 'off') {
+      if (keyboardControlsStatus !== 'off') {
         // Possible bug requires testing: is Runtime ok with mixed input sources in same packet?
         inputs.push(
           new RobotInput({
-            connected: keyboardControlsEnabled === 'on',
+            connected: keyboardControlsStatus === 'on',
             axes: [],
-            buttons: keyboardControlsEnabled ? Number(keyboardBitmap) : 0,
+            buttons: keyboardControlsStatus ? Number(keyboardBitmap) : 0,
             source: RobotInputSource.KEYBOARD,
           }),
         );
-        if (keyboardControlsEnabled === 'offEdge') {
+        if (keyboardControlsStatus === 'offEdge') {
           setKeyboardControlsEnabled('off');
         }
       }
@@ -303,7 +303,7 @@ export default function App() {
       window.removeEventListener('keydown', onKeyDown);
       window.removeEventListener('keyup', onKeyUp);
     };
-  }, [keyboardControlsEnabled]);
+  }, [keyboardControlsStatus]);
   useEffect(() => {
     // Tests won't run main/preload.ts
     if (window.electron) {
@@ -418,7 +418,7 @@ export default function App() {
             content={editorContent}
             consoleAlert={consoleIsAlerted}
             consoleIsOpen={consoleIsOpen}
-            keyboardControlsEnabled={keyboardControlsEnabled}
+            keyboardControlsStatus={keyboardControlsStatus}
             robotConnected={robotLatencyMs !== -1}
             robotRunning={robotRunning}
             onOpen={loadFile}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -74,7 +74,9 @@ export default function App() {
   // closed)
   const [consoleIsAlerted, setConsoleIsAlerted] = useState(false);
   // Whether keyboard controls are enabled.
-  const [keyboardControlsEnabled, setKeyboardControlsEnabled] = useState('on' as KeyboardControlsStatus);
+  const [keyboardControlsEnabled, setKeyboardControlsEnabled] = useState(
+    'on' as KeyboardControlsStatus,
+  );
   // Whether the robot is running student code
   const [robotRunning, setRobotRunning] = useState(false);
   // Most recent window.innerWidth/Height needed to clamp editor and col size
@@ -285,15 +287,17 @@ export default function App() {
             source: RobotInputSource.GAMEPAD,
           });
         });
-      if (keyboardControlsEnabled != 'off') {
+      if (keyboardControlsEnabled !== 'off') {
         // Possible bug requires testing: is Runtime ok with mixed input sources in same packet?
-        inputs.push(new RobotInput({
-          connected: keyboardControlsEnabled == 'on',
-          axes: [],
-          buttons: keyboardControlsEnabled ? Number(keyboardBitmap) : 0,
-          source: RobotInputSource.KEYBOARD,
-        }));
-        if (keyboardControlsEnabled == 'offEdge') {
+        inputs.push(
+          new RobotInput({
+            connected: keyboardControlsEnabled === 'on',
+            axes: [],
+            buttons: keyboardControlsEnabled ? Number(keyboardBitmap) : 0,
+            source: RobotInputSource.KEYBOARD,
+          }),
+        );
+        if (keyboardControlsEnabled === 'offEdge') {
           setKeyboardControlsEnabled('off');
         }
       }
@@ -443,7 +447,7 @@ export default function App() {
               setConsoleIsAlerted(false);
             }}
             onToggleKeyboardControls={() => {
-              setKeyboardControlsEnabled((v) => v == 'on' ? 'offEdge' : 'on');
+              setKeyboardControlsEnabled((v) => (v === 'on' ? 'offEdge' : 'on'));
             }}
           />
           <ResizeBar

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -447,7 +447,9 @@ export default function App() {
               setConsoleIsAlerted(false);
             }}
             onToggleKeyboardControls={() => {
-              setKeyboardControlsEnabled((v) => (v === 'on' ? 'offEdge' : 'on'));
+              setKeyboardControlsEnabled((v) =>
+                v === 'on' ? 'offEdge' : 'on',
+              );
             }}
           />
           <ResizeBar

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -181,12 +181,7 @@ export default function App() {
       fieldStationNumber: FieldStationNum,
       showDirtyUploadWarning,
     });
-  }, [
-    IPAddress,
-    FieldIPAddress,
-    FieldStationNum,
-    showDirtyUploadWarning,
-  ]);
+  }, [IPAddress, FieldIPAddress, FieldStationNum, showDirtyUploadWarning]);
   const saveFile = useCallback(
     (forceDialog: boolean) => {
       window.electron.ipcRenderer.sendMessage('main-file-control', {

--- a/src/renderer/DeviceInfo.tsx
+++ b/src/renderer/DeviceInfo.tsx
@@ -1,4 +1,4 @@
-import DeviceInfoState, { DeviceTypes } from '../common/DeviceInfoState';
+import DeviceInfoState, { DeviceTypeNames } from '../common/DeviceInfoState';
 import './DeviceInfo.css';
 
 /**
@@ -19,8 +19,8 @@ export default function DeviceInfo({
         deviceStates.map((device) => {
           const deviceTypeNum = Number(device.id.split('_')[0]);
           const deviceType =
-            deviceTypeNum in DeviceTypes
-              ? DeviceTypes[deviceTypeNum]
+            deviceTypeNum in DeviceTypeNames
+              ? DeviceTypeNames[deviceTypeNum]
               : 'Unknown device';
           return (
             <div className="DeviceInfo-device" key={device.id}>

--- a/src/renderer/Editor.tsx
+++ b/src/renderer/Editor.tsx
@@ -218,7 +218,9 @@ export default function Editor({
             type="button"
             onClick={onToggleKeyboardControls}
             className={
-              keyboardControlsStatus === 'on' ? 'Editor-tbbtn-toggled' : undefined
+              keyboardControlsStatus === 'on'
+                ? 'Editor-tbbtn-toggled'
+                : undefined
             }
             title="Toggle keyboard controls"
           >

--- a/src/renderer/Editor.tsx
+++ b/src/renderer/Editor.tsx
@@ -21,6 +21,10 @@ import './Editor.css';
  */
 export type EditorContentStatus = 'clean' | 'dirty' | 'extDirty';
 
+/**
+ * A status of keyboard controls. Would be a simple boolean if we didn't need a way to prevent
+ * duplicate empty "keyboard disconnected" input objects to be sent to Runtime.
+ */
 export type KeyboardControlsStatus = 'off' | 'on' | 'offEdge';
 
 /**
@@ -135,7 +139,7 @@ export default function Editor({
   return (
     <div
       className={`Editor${
-        keyboardControlsEnabled == 'on' ? ' Editor-kbctrl-enabled' : ''
+        keyboardControlsEnabled === 'on' ? ' Editor-kbctrl-enabled' : ''
       }`}
       style={{ width }}
     >
@@ -272,7 +276,7 @@ export default function Editor({
           mode="python"
           onChange={onChange}
           value={content}
-          readOnly={keyboardControlsEnabled == 'on'}
+          readOnly={keyboardControlsEnabled === 'on'}
         />
       </div>
     </div>

--- a/src/renderer/Editor.tsx
+++ b/src/renderer/Editor.tsx
@@ -57,7 +57,7 @@ const STATUS_TEXT: { [k in EditorContentStatus]: string } = {
  * indicating the user's attention is needed
  * @param props.consoleIsOpen - whether to show a different icon for the toggle console button
  * indicating the console is open
- * @param props.keyboardControlsEnabled - whether to show a different icon for the toggle keyboard
+ * @param props.keyboardControlsStatus - whether to show a different icon for the toggle keyboard
  * control button indicating keyboard control is enabled
  * @param props.robotConnected - whether toolbar buttons requiring a connection to the robot should
  * be enabled.
@@ -82,7 +82,7 @@ export default function Editor({
   content,
   consoleAlert,
   consoleIsOpen,
-  keyboardControlsEnabled,
+  keyboardControlsStatus,
   robotConnected,
   robotRunning,
   onOpen,
@@ -107,7 +107,7 @@ export default function Editor({
   content: string;
   consoleAlert: boolean;
   consoleIsOpen: boolean;
-  keyboardControlsEnabled: KeyboardControlsStatus;
+  keyboardControlsStatus: KeyboardControlsStatus;
   robotConnected: boolean;
   robotRunning: boolean;
   onOpen: () => void;
@@ -139,7 +139,7 @@ export default function Editor({
   return (
     <div
       className={`Editor${
-        keyboardControlsEnabled === 'on' ? ' Editor-kbctrl-enabled' : ''
+        keyboardControlsStatus === 'on' ? ' Editor-kbctrl-enabled' : ''
       }`}
       style={{ width }}
     >
@@ -218,7 +218,7 @@ export default function Editor({
             type="button"
             onClick={onToggleKeyboardControls}
             className={
-              keyboardControlsEnabled ? 'Editor-tbbtn-toggled' : undefined
+              keyboardControlsStatus === 'on' ? 'Editor-tbbtn-toggled' : undefined
             }
             title="Toggle keyboard controls"
           >
@@ -276,7 +276,7 @@ export default function Editor({
           mode="python"
           onChange={onChange}
           value={content}
-          readOnly={keyboardControlsEnabled === 'on'}
+          readOnly={keyboardControlsStatus === 'on'}
         />
       </div>
     </div>

--- a/src/renderer/Editor.tsx
+++ b/src/renderer/Editor.tsx
@@ -21,6 +21,8 @@ import './Editor.css';
  */
 export type EditorContentStatus = 'clean' | 'dirty' | 'extDirty';
 
+export type KeyboardControlsStatus = 'off' | 'on' | 'offEdge';
+
 /**
  * Tooltips to display over the editor status indicator.
  */
@@ -101,7 +103,7 @@ export default function Editor({
   content: string;
   consoleAlert: boolean;
   consoleIsOpen: boolean;
-  keyboardControlsEnabled: boolean;
+  keyboardControlsEnabled: KeyboardControlsStatus;
   robotConnected: boolean;
   robotRunning: boolean;
   onOpen: () => void;
@@ -133,7 +135,7 @@ export default function Editor({
   return (
     <div
       className={`Editor${
-        keyboardControlsEnabled ? ' Editor-kbctrl-enabled' : ''
+        keyboardControlsEnabled == 'on' ? ' Editor-kbctrl-enabled' : ''
       }`}
       style={{ width }}
     >
@@ -270,7 +272,7 @@ export default function Editor({
           mode="python"
           onChange={onChange}
           value={content}
-          readOnly={keyboardControlsEnabled}
+          readOnly={keyboardControlsEnabled == 'on'}
         />
       </div>
     </div>

--- a/src/renderer/Topbar.tsx
+++ b/src/renderer/Topbar.tsx
@@ -58,7 +58,7 @@ export default function Topbar({
     ) : (
       <>
         <div className={`Topbar-info-card ${batteryColor}`}>
-          Battery: {robotBatteryVoltage} V
+          Battery: {Math.floor(robotBatteryVoltage * 100) / 100} V
         </div>
         <div className={`Topbar-info-card ${latencyColor}`}>
           Latency: {robotLatencyMs} ms

--- a/src/renderer/modals/ConnectionConfigModal.tsx
+++ b/src/renderer/modals/ConnectionConfigModal.tsx
@@ -5,10 +5,7 @@ import './ConnectionConfigModal.css';
 /**
  * Names of fields in ConnectionConfigModal.
  */
-export type ConfigName =
-  | 'IPAddress'
-  | 'FieldIPAddress'
-  | 'FieldStationNum';
+export type ConfigName = 'IPAddress' | 'FieldIPAddress' | 'FieldStationNum';
 /**
  * Event data for ConnectionConfigModal onChange handler.
  */

--- a/src/renderer/modals/ConnectionConfigModal.tsx
+++ b/src/renderer/modals/ConnectionConfigModal.tsx
@@ -7,7 +7,6 @@ import './ConnectionConfigModal.css';
  */
 export type ConfigName =
   | 'IPAddress'
-  | 'SSHAddress'
   | 'FieldIPAddress'
   | 'FieldStationNum';
 /**
@@ -30,7 +29,6 @@ export interface ConnectionConfigChangeEvent {
  * @param props.onClose - handler called when the modal is closed by any means
  * @param props.isActive - whether to display the modal
  * @param props.IPAddress - displayed robot IP address
- * @param props.SSHAddress - displayed robot SSH address
  * @param props.FieldIPAddress - displayed field IP address
  * @param props.FieldStationNum - displayed field station number
  */
@@ -39,7 +37,6 @@ export default function ConnectionConfigModal({
   isActive,
   onChange,
   IPAddress,
-  SSHAddress,
   FieldIPAddress,
   FieldStationNum,
 }: {
@@ -51,7 +48,6 @@ export default function ConnectionConfigModal({
   onChange: (e: ConnectionConfigChangeEvent) => void;
   isActive: boolean;
   IPAddress: string;
-  SSHAddress: string;
   FieldIPAddress: string;
   FieldStationNum: string;
 }) {
@@ -73,22 +69,11 @@ export default function ConnectionConfigModal({
         htmlFor="ConnectionConfigModal-IPAddress"
         className="ConnectionConfigModal-config-field"
       >
-        IP Address:
+        Robot IP Address:
         <input
           name="ConnectionConfigModal-IPAddress"
           onChange={handleConfigChange}
           value={IPAddress}
-        />
-      </label>
-      <label
-        htmlFor="ConnectionConfigModal-SSHAddress"
-        className="ConnectionConfigModal-config-field"
-      >
-        SSH Address:
-        <input
-          name="ConnectionConfigModal-SSHAddress"
-          onChange={handleConfigChange}
-          value={SSHAddress}
         />
       </label>
       <div className="ConnectionConfigModal-section">


### PR DESCRIPTION
- **Change SSH login**
  Use the correct SSH login for this season.
- **Fix PacketStream bug**
  Stop sending unchunked buffers from being emitted as packets. Caused by misunderstanding of \_transform callback.
- **Only send one keyboard packet per kbctrl disable**
  Stop telling Runtime keyboard input is disabled every time we send an input packet.
- **Uncomment writing robot logs to console**
  We need those!
- **Lint**
- **Lint part 2**
- **Remove all mention of CHALLENGE_DATA**
  Shepherd does this now.
- **Suppress redundant 'robot disconencted' messages**
  Only print connection errors for the first attempt when the robot is disconnected. The user doesn't need to be informed every 5 seconds that, no, the robot isn't connected yet.
- **Merge IPAddress and SSHAddress fields**
  Wisdom from the gods (Ben) suggests these would only be different for remote events, so now ConnectionConfigModal only has one "Robot IP Address" field that is used both for SSH and Runtime connections.
- **Send robot-battery-update events from device data**
  Pull out the v\_batt parameter from the PDB every time we receive device data and use it to update the battery voltage displayed in the Topbar.
- **Remove UDP stuff**
  Inputs are also sent over TCP now, so nothing needs the UDP socket and we certainly don't need to set up the forwarding that old Dawn does.
- **Fix latency test**
  Do math on the actual timestamp, not the packet it's contained in.
- **Remove reference to CHALLENGE_DATA stuff**
  Missed some last time.
- **Fix #22 keyboard control weirdness**
  After changing kbctrl to be tri-state (on, off, off-edge) to remove repeated kbctrl disabled inputs, some logic still treated it as a true/false value and in the confusion 'on' became the default instead of 'off'. Note commit summary has wrong issue number.
- **Lint again**
  Also remove last remnants of UDP packet handling.

Fixes #24.
Fixes #22.
