### PR TITLE
Catch more protos errors

### DIFF
--- a/src/main/network/RuntimeComms.ts
+++ b/src/main/network/RuntimeComms.ts
@@ -275,7 +275,8 @@ export default class RuntimeComms {
           break;
         case MsgType.TIME_STAMPS:
           this.#commsListener.onReceiveLatency(
-            (Date.now() - Number(protos.TimeStamps.decode(data).dawnTimestamp)) /
+            (Date.now() -
+              Number(protos.TimeStamps.decode(data).dawnTimestamp)) /
               2,
           );
           break;


### PR DESCRIPTION
Wrap the entire packet processing method in RuntimeComms in try/catch and report errors using the onRuntimeError method of the listener.