### PR TITLE
Added auto-scroll toggle and additional auto-scroll behavior

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -74,6 +74,8 @@ export default function App() {
   const [consoleMsgs, setConsoleMsgs] = useState([] as AppConsoleMessage[]);
   // Whether the AppConsole is open
   const [consoleIsOpen, setConsoleIsOpen] = useState(true);
+  // Whether the AppConsole will have auto-scroll
+  const [consoleAutoScroll, setConsoleAutoScroll] = useState(false);
   // Whether a new message has been added to the AppConsole since it has been closed (if it is
   // closed)
   const [consoleIsAlerted, setConsoleIsAlerted] = useState(false);
@@ -451,6 +453,13 @@ export default function App() {
               setConsoleMsgs([]);
               setConsoleIsAlerted(false);
             }}
+            onToggleAutoScroll={() => {
+              if (!consoleAutoScroll) {
+                setConsoleAutoScroll(true);
+              } else {
+                setConsoleAutoScroll(false);
+              }
+            }}
             onToggleKeyboardControls={() => {
               setKeyboardControlsEnabled((v) =>
                 v === 'on' ? 'offEdge' : 'on',
@@ -473,7 +482,11 @@ export default function App() {
               onEndResize={endColsResize}
               axis="y"
             />
-            <AppConsole height={consoleSize} messages={consoleMsgs} />
+            <AppConsole
+              height={consoleSize}
+              messages={consoleMsgs}
+              autoscroll={consoleAutoScroll}
+            />
           </>
         )}
         <div className="App-modal-container">

--- a/src/renderer/AppConsole.tsx
+++ b/src/renderer/AppConsole.tsx
@@ -1,32 +1,58 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import AppConsoleMessage from '../common/AppConsoleMessage';
 import './AppConsole.css';
+import { contextIsolated } from 'process';
 
 /**
  * Component displaying output and error messages from student code ran on the robot.
  * @param props - props
  * @param props.height - the height of the console in pixels
  * @param props.messages - array of console messages to display
+ * @param props.autoscroll - whether auto-scrolling is enabled
  */
 export default function AppConsole({
   height,
   messages,
+  autoscroll,
 }: {
   height: number;
   messages: AppConsoleMessage[];
+  autoscroll: boolean;
 }) {
   // Add autoscroll feature to AppConsole by setting the current scrollTop prop to the current scrollHeight value
   const consoleRef = useRef<HTMLPreElement>(null);
+  const [scrolledUp, setScrolledUp] = useState(false);
+
+  const handleScroll = () => {
+    if (!consoleRef.current) {
+      return;
+    }
+
+    const { scrollTop, scrollHeight, clientHeight } = consoleRef.current;
+    const isAtBottom = scrollHeight - scrollTop - clientHeight < 10;
+
+    if (isAtBottom) {
+      setScrolledUp(false);
+    } else {
+      setScrolledUp(true);
+    }
+  };
 
   useEffect(() => {
-    if (consoleRef.current) {
+    const shouldAutoScroll = autoscroll && !scrolledUp;
+
+    if (shouldAutoScroll && consoleRef.current) {
       consoleRef.current.scrollTop = consoleRef.current.scrollHeight;
     }
-  }, [messages]);
+  }, [messages, autoscroll, scrolledUp]);
 
   return (
     <div className="AppConsole" style={{ height }}>
-      <pre ref={consoleRef} className="AppConsole-inner">
+      <pre
+        ref={consoleRef}
+        className="AppConsole-inner"
+        onScroll={handleScroll}
+      >
         {messages.map((msg: AppConsoleMessage) => (
           <div
             key={msg.uuid}

--- a/src/renderer/editor/Editor.css
+++ b/src/renderer/editor/Editor.css
@@ -126,3 +126,11 @@
   margin-left: 5px;
   outline: none;
 }
+.Editor-auto-scroll-button {
+  width: auto;
+  height: 20px; 
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  outline: none; 
+}

--- a/src/renderer/editor/Editor.tsx
+++ b/src/renderer/editor/Editor.tsx
@@ -129,6 +129,7 @@ export default function Editor({
   onStartRobot,
   onStopRobot,
   onToggleConsole,
+  onToggleAutoScroll,
   onClearConsole,
   onToggleKeyboardControls,
 }: {
@@ -164,6 +165,7 @@ export default function Editor({
   onStopRobot: () => void;
   onToggleConsole: () => void;
   onClearConsole: () => void;
+  onToggleAutoScroll: () => void;
   onToggleKeyboardControls: () => void;
 }) {
   const [opmode, setOpmode] = useState('auto');
@@ -255,6 +257,14 @@ export default function Editor({
           </button>
           <button type="button" onClick={onClearConsole} title="Clear console">
             <img src={consoleClearSvg} alt="Clear console" />
+          </button>
+          <button
+            type="button"
+            title="Turn on auto-scroll"
+            className="Editor-auto-scroll-button"
+            onClick={onToggleAutoScroll}
+          >
+            ↕
           </button>
         </div>
         <div className="Editor-toolbar-group">


### PR DESCRIPTION
Added an auto-scroll toggle button (identified by ↕) in Editor.tsx, as well as an additional behavior that disables autoscroll when the user scrolls up (even when autoscroll is already toggled)

Note: auto-scroll is not enabled by default and the user must click the toggle button to enable/disable the auto-scrolling feature. 

The method for toggling auto-scroll is a prop for Editor.tsx, while there is also a boolean prop "autoscroll" at AppConsole.tsx to control whether auto-scroll is enabled. The onToggleAutoScroll function is defined in App.tsx. 

The useEffect hook and handleScroll function was also adjusted to reflect these new behaviors. 