### PR TITLE
implemented a temporary fix to console rearrangement

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -58,3 +58,16 @@ body {
 .link-light {
   color: blue;
 }
+.editor-container {
+  display: flex; 
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+.editor-container > * {
+  flex-shrink: 0; 
+}
+.editor-container > :first-child {
+  flex: 1;
+  min-height: 0; 
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -436,52 +436,71 @@ export default function App() {
           isDarkMode={isDarkMode}
         />
         <div className="App-cols">
-          <Editor
-            width={editorSize}
-            onChange={changeEditorContent}
-            fileStatus={editorStatus}
-            filePath={editorPath}
-            content={editorContent}
-            consoleAlert={consoleIsAlerted}
-            consoleIsOpen={consoleIsOpen}
-            keyboardControlsStatus={keyboardControlsStatus}
-            robotConnected={robotLatencyMs !== -1}
-            robotRunning={robotRunning}
-            onOpen={loadFile}
-            onSave={saveFile}
-            onNewFile={createNewFile}
-            onLoadStaffCode={loadStaffCode}
-            onRobotUpload={() => uploadDownloadFile(true)}
-            onRobotDownload={() => uploadDownloadFile(false)}
-            onStartRobot={(opmode: 'auto' | 'teleop') => {
-              changeRunMode(
-                opmode === 'auto' ? RobotRunMode.AUTO : RobotRunMode.TELEOP,
-              );
-            }}
-            onStopRobot={() => changeRunMode(RobotRunMode.IDLE)}
-            onToggleConsole={() => {
-              setConsoleIsOpen((v) => !v);
-              setConsoleIsAlerted(false);
-            }}
-            onClearConsole={() => {
-              setConsoleMsgs([]);
-              setConsoleIsAlerted(false);
-            }}
-            onToggleAutoScroll={() => {
-              if (!consoleAutoScroll) {
-                setConsoleAutoScroll(true);
-              } else {
-                setConsoleAutoScroll(false);
-              }
-            }}
-            onToggleKeyboardControls={() => {
-              setKeyboardControlsEnabled((v) =>
-                v === 'on' ? 'offEdge' : 'on',
-              );
-            }}
-            isDarkMode={isDarkMode}
-            onToggleDarkMode={toggleDarkMode}
-          />
+          <div className="editor-container">
+            <Editor
+              width={editorSize}
+              onChange={changeEditorContent}
+              fileStatus={editorStatus}
+              filePath={editorPath}
+              content={editorContent}
+              consoleAlert={consoleIsAlerted}
+              consoleIsOpen={consoleIsOpen}
+              keyboardControlsStatus={keyboardControlsStatus}
+              robotConnected={robotLatencyMs !== -1}
+              robotRunning={robotRunning}
+              onOpen={loadFile}
+              onSave={saveFile}
+              onNewFile={createNewFile}
+              onLoadStaffCode={loadStaffCode}
+              onRobotUpload={() => uploadDownloadFile(true)}
+              onRobotDownload={() => uploadDownloadFile(false)}
+              onStartRobot={(opmode: 'auto' | 'teleop') => {
+                changeRunMode(
+                  opmode === 'auto' ? RobotRunMode.AUTO : RobotRunMode.TELEOP,
+                );
+              }}
+              onStopRobot={() => changeRunMode(RobotRunMode.IDLE)}
+              onToggleConsole={() => {
+                setConsoleIsOpen((v) => !v);
+                setConsoleIsAlerted(false);
+              }}
+              onClearConsole={() => {
+                setConsoleMsgs([]);
+                setConsoleIsAlerted(false);
+              }}
+              onToggleAutoScroll={() => {
+                if (!consoleAutoScroll) {
+                  setConsoleAutoScroll(true);
+                } else {
+                  setConsoleAutoScroll(false);
+                }
+              }}
+              onToggleKeyboardControls={() => {
+                setKeyboardControlsEnabled((v) =>
+                  v === 'on' ? 'offEdge' : 'on',
+                );
+              }}
+              isDarkMode={isDarkMode}
+              onToggleDarkMode={toggleDarkMode}
+            />
+            {consoleIsOpen && (
+              <>
+                <ResizeBar
+                  onStartResize={startColsResize}
+                  onUpdateResize={updateColsResize}
+                  onEndResize={endColsResize}
+                  axis="y"
+                  isDarkMode={isDarkMode}
+                />
+                <AppConsole
+                  height={consoleSize}
+                  messages={consoleMsgs}
+                  isDarkMode={isDarkMode}
+                  autoscroll={consoleAutoScroll}
+                />
+              </>
+            )}
+          </div>
           <ResizeBar
             onStartResize={startEditorResize}
             onUpdateResize={updateEditorResize}
@@ -491,23 +510,6 @@ export default function App() {
           />
           <DeviceInfo deviceStates={deviceInfoState} isDarkMode={isDarkMode} />
         </div>
-        {consoleIsOpen && (
-          <>
-            <ResizeBar
-              onStartResize={startColsResize}
-              onUpdateResize={updateColsResize}
-              onEndResize={endColsResize}
-              axis="y"
-              isDarkMode={isDarkMode}
-            />
-            <AppConsole
-              height={consoleSize}
-              messages={consoleMsgs}
-              isDarkMode={isDarkMode}
-              autoscroll={consoleAutoScroll}
-            />
-          </>
-        )}
         <div className="App-modal-container">
           <ConnectionConfigModal
             isActive={activeModal === 'ConnectionConfig'}

--- a/src/renderer/editor/Editor.tsx
+++ b/src/renderer/editor/Editor.tsx
@@ -389,7 +389,7 @@ export default function Editor({
             <img src={stopRobot} alt="Stop robot" />
           </button>
         </div>
-        <div></div>
+        <div aria-hidden="true" />
       </div>
       <div className="Editor-ace-wrapper">
         <div className="Editor-kbctrl-overlay">

--- a/src/renderer/editor/Editor.tsx
+++ b/src/renderer/editor/Editor.tsx
@@ -336,12 +336,6 @@ export default function Editor({
               </option>
             ))}
           </select>
-        </div>
-        <div
-          className={`Editor-toolbar-group Editor-toolbar-group-${
-            isDarkMode ? 'dark' : 'light'
-          }`}
-        >
           <button
             type="button"
             className="Editor-toolbar-button"
@@ -395,6 +389,7 @@ export default function Editor({
             <img src={stopRobot} alt="Stop robot" />
           </button>
         </div>
+        <div></div>
       </div>
       <div className="Editor-ace-wrapper">
         <div className="Editor-kbctrl-overlay">


### PR DESCRIPTION
NOTE: Temporary fix due to the production schedule. 

Grouped the Editor and AppConsole (and its ResizeBar) together in a single div (which are allowed to take up to 70% of the screen). 

Led to a new issue where the ResizeBar of the DeviceInfo component was changing the position of the elements and divs associated with OpMode selection. 

Temporary fix: Added an empty div buffer between OpMode selection and DeviceInfo's ResizeBar component. Someone please look into a potential fix (you may need to change the methods that control how things are resized). I also grouped the dark mode toggle button with the editor theme selection for better classification. 

![image](https://github.com/user-attachments/assets/f657c6bf-f642-4d40-9e99-153c017bde74)