### PR TITLE
Prevent opmode dropdown floating to right and remove hacky fix

### DIFF
--- a/src/renderer/editor/Editor.css
+++ b/src/renderer/editor/Editor.css
@@ -138,9 +138,11 @@
 .Editor-toolbar-group > *:not(:last-child) {
   margin-right: 6px;
 }
+/*
 .Editor-toolbar-group:last-child {
   margin-left: auto;
 }
+*/
 /* light mode */
 .Editor-toolbar-light button {
   position: relative;

--- a/src/renderer/editor/Editor.tsx
+++ b/src/renderer/editor/Editor.tsx
@@ -389,7 +389,6 @@ export default function Editor({
             <img src={stopRobot} alt="Stop robot" />
           </button>
         </div>
-        <div aria-hidden="true" />
       </div>
       <div className="Editor-ace-wrapper">
         <div className="Editor-kbctrl-overlay">


### PR DESCRIPTION
The run mode section of the editor toolbar floated to the right, which was intentional but looked
weird. To fix this, febaf65 added an empty spacer that the :last-child rule affected instead. This
Pr removes the spacer and the unwanted :last-child rule.

Fixes #45. (Not really, but the actual PR didn't link ths issue.)
