### PR TITLE
Update protos.d.ts to force long usage - makes dev/prod work in the electron application build.

### DIFF
--- a/protos-main/protos.d.ts
+++ b/protos-main/protos.d.ts
@@ -1,4 +1,9 @@
 import * as $protobuf from "protobufjs";
+import Long from "long";
+
+$protobuf.util.Long = Long;
+$protobuf.configure();
+
 /** Properties of a Param. */
 export interface IParam {
 

--- a/protos-main/protos.js
+++ b/protos-main/protos.js
@@ -1,6 +1,9 @@
 /*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
 import * as $protobuf from "protobufjs/minimal";
+import Long from "long";
 
+$protobuf.util.Long = Long;
+$protobuf.configure();
 // Common aliases
 const $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
 


### PR DESCRIPTION
Hello Team!  This change makes it so that protobuf is FORCED to use the long class for any int64 values that come over the wire.

The trick is - your version of protobufjs doesn't give an easy way to force this in the compilation.

So... to make this work with your build.  I fist compile the protobuf classes.  Then I had to HAND add these three lines to the JS file that was generated.

You could do this in your build script, and there may be other ways to ensure the compiler does it BUT this proves this is the root of the problem.